### PR TITLE
Fix integration production separation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install helm
         uses: azure/setup-helm@v3
+        with:
+          version: 3.10.0
       - run: helm lint .
 
       - name: Setup k3s/k3d

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,4 +41,4 @@ RUN --mount=type=cache,target=/root/.cache \
 
 WORKDIR /app
 COPY operator_.py ./
-CMD ["kopf", "run", "operator_.py"]
+ENTRYPOINT ["kopf", "run", "operator_.py"]

--- a/docker/operator_.py
+++ b/docker/operator_.py
@@ -6,8 +6,6 @@ import os
 from typing import Any, Dict
 
 import kopf
-import kopf._cogs.structs.bodies
-import kopf._core.actions.execution
 import requests
 
 AUTH_HEADER = f"Bearer {os.environ['GITHUB_TOKEN']}"
@@ -16,19 +14,17 @@ TIMEOUT = int(os.environ.get("REQUESTS_TIMEOUT", "10"))
 
 
 @kopf.on.startup()
-def startup(settings: kopf.OperatorSettings, logger: kopf._cogs.helpers.typedefs.Logger, **_) -> None:
+def startup(settings: kopf.OperatorSettings, logger: kopf.Logger, **_) -> None:
     settings.posting.level = logging.getLevelName(os.environ.get("LOG_LEVEL", "INFO"))
     if "KOPF_SERVER_TIMEOUT" in os.environ:
         settings.watching.server_timeout = int(os.environ["KOPF_SERVER_TIMEOUT"])
     if "KOPF_CLIENT_TIMEOUT" in os.environ:
         settings.watching.client_timeout = int(os.environ["KOPF_CLIENT_TIMEOUT"])
-    logger.info("GitHub WebHook creator started")
+    logger.info("GitHub WebHook creator started in environment %s", ENVIRONMENT)
     logger.debug("Start date: %s", datetime.datetime.now())
 
 
-def create_webhook(
-    spec: kopf._cogs.structs.bodies.Spec, logger: kopf._cogs.helpers.typedefs.Logger
-) -> Dict[str, Any]:
+def create_webhook(spec: kopf.Spec, logger: kopf.Logger) -> Dict[str, Any]:
     webhooks_response = requests.get(
         f"https://api.github.com/repos/{spec['repository']}/hooks",
         headers={
@@ -81,7 +77,7 @@ def create_webhook(
     return {"ghId": result.json()["id"]}
 
 
-def delete_webhook(url: str, repository: str, id_: int, logger: kopf._cogs.helpers.typedefs.Logger) -> None:
+def delete_webhook(url: str, repository: str, id_: int, logger: kopf.Logger) -> None:
     result = requests.delete(
         f"https://api.github.com/repos/{repository}/hooks/{id_}",
         headers={
@@ -97,31 +93,16 @@ def delete_webhook(url: str, repository: str, id_: int, logger: kopf._cogs.helpe
         logger.debug(result.text)
 
 
-@kopf.on.resume("camptocamp.com", "v3", "githubwebhooks")
-@kopf.on.create("camptocamp.com", "v3", "githubwebhooks")
-async def create(
-    meta: kopf._cogs.structs.bodies.Meta,
-    spec: kopf._cogs.structs.bodies.Spec,
-    logger: kopf._cogs.helpers.typedefs.Logger,
-    **_,
-) -> Dict[str, Any]:
-    if spec["environment"] != ENVIRONMENT:
-        return {}
+@kopf.on.resume("camptocamp.com", "v3", "githubwebhooks", field="spec.environment", value=ENVIRONMENT)
+@kopf.on.create("camptocamp.com", "v3", "githubwebhooks", field="spec.environment", value=ENVIRONMENT)
+async def create(meta: kopf.Meta, spec: kopf.Spec, logger: kopf.Logger, **_) -> Dict[str, Any]:
     logger.info("Create, Name: %s, Namespace: %s", meta.get("name"), meta.get("namespace"))
 
     return create_webhook(spec, logger)
 
 
-@kopf.on.delete("camptocamp.com", "v3", "githubwebhooks")
-async def delete(
-    meta: kopf._cogs.structs.bodies.Meta,
-    spec: kopf._cogs.structs.bodies.Spec,
-    status: kopf._cogs.structs.bodies.Status,
-    logger: kopf._cogs.helpers.typedefs.Logger,
-    **_,
-) -> None:
-    if spec["environment"] != ENVIRONMENT:
-        return
+@kopf.on.delete("camptocamp.com", "v3", "githubwebhooks", field="spec.environment", value=ENVIRONMENT)
+async def delete(meta: kopf.Meta, spec: kopf.Spec, status: kopf.Status, logger: kopf.Logger, **_) -> None:
     my_status = _get_status(status)
     logger.info(
         "Delete, Name: %s, Namespace: %s, Status: %s", meta.get("name"), meta.get("namespace"), my_status
@@ -130,16 +111,10 @@ async def delete(
         delete_webhook(spec["url"], spec["repository"], my_status["ghId"], logger)
 
 
-@kopf.on.update("camptocamp.com", "v3", "githubwebhooks")
+@kopf.on.update("camptocamp.com", "v3", "githubwebhooks", field="spec.environment", value=ENVIRONMENT)
 async def update(
-    meta: kopf._cogs.structs.bodies.Meta,
-    spec: kopf._cogs.structs.bodies.Spec,
-    status: kopf._cogs.structs.bodies.Status,
-    logger: kopf._cogs.helpers.typedefs.Logger,
-    **_,
+    meta: kopf.Meta, spec: kopf.Spec, status: kopf.Status, logger: kopf.Logger, **_
 ) -> Dict[str, Any]:
-    if spec["environment"] != ENVIRONMENT:
-        return {}
     my_status = _get_status(status)
     logger.info(
         "Update, Name: %s, Namespace: %s, Status: %s", meta.get("name"), meta.get("namespace"), my_status
@@ -149,7 +124,7 @@ async def update(
     return create_webhook(spec, logger)
 
 
-def _get_status(status: kopf._cogs.structs.bodies.Status) -> Dict[str, Any]:
+def _get_status(status: kopf.Status) -> Dict[str, Any]:
     for key in ["update", "create"]:
         if key in status:
             return status[key]

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,23 +28,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}}}
+          {{- with .Values.command }}
           command:
-          {{- if .Values.command }}
-          {{- range .Values.command }}
-            - {{ . }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- else }}
-            - kopf
-            - run
-          {{- end }}
+          {{- with .Values.args }}
           args:
-          {{- if .Values.args }}
-          {{- range .Values.args }}
-            - {{ . }}
-          {{- end }}
-          {{- else }}
-            - operator_.py
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           securityContext:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -29,11 +29,12 @@ def install_operator(scope="session"):
                 "--namespace=default",
                 f"--set=image.tag=latest,env.GITHUB_TOKEN={os.environ['GITHUB_TOKEN']},"
                 "env.LOG_LEVEL=DEBUG,env.ENVIRONMENT=test",
+                '--set-json=args=["--debug"]',
             ],
             stdout=operator_file,
             check=True,
         )
-    subprocess.run(["kubectl", "apply", "-f", "operator.yaml"], check=True)
+    subprocess.run(["kubectl", "apply", "--filename=operator.yaml"], check=True)
 
     pods = []
     success = False
@@ -55,7 +56,7 @@ def install_operator(scope="session"):
 
     yield
     # We should have the pod to be able to extract the logs
-    # subprocess.run(["kubectl", "delete", "-f", "operator.yaml"], check=True)
+    # subprocess.run(["kubectl", "delete", "--filename=operator.yaml"], check=True)
     os.remove("operator.yaml")
 
 
@@ -95,7 +96,7 @@ def test_operator(install_operator):
     del install_operator
 
     # Initialize the source and the config
-    subprocess.run(["kubectl", "delete", "-f", "tests/webhook.yaml"])
+    subprocess.run(["kubectl", "delete", "--filename=tests/webhook.yaml"])
 
     # Clean the old webhook
     webhooks = requests.get(
@@ -116,15 +117,15 @@ def test_operator(install_operator):
 
     # Test creation
     LOG.warning("Test creation: %s", datetime.datetime.now())
-    subprocess.run(["kubectl", "apply", "-f", "tests/webhook.yaml"], check=True)
+    subprocess.run(["kubectl", "apply", "--filename=tests/webhook.yaml"], check=True)
     _assert_webhooks(1, "json", "https://example.com", "my-secret")
 
     # Test modification
     LOG.warning("Test modification: %s", datetime.datetime.now())
-    subprocess.run(["kubectl", "apply", "-f", "tests/webhook-form.yaml"], check=True)
+    subprocess.run(["kubectl", "apply", "--filename=tests/webhook-form.yaml"], check=True)
     _assert_webhooks(1, "form", "https://example.com", "my-secret")
 
     # Test remove
     LOG.warning("Test remove: %s", datetime.datetime.now())
-    subprocess.run(["kubectl", "delete", "-f", "tests/webhook-form.yaml"], check=True)
+    subprocess.run(["kubectl", "delete", "--filename=tests/webhook-form.yaml"], check=True)
     _assert_webhooks(0)


### PR DESCRIPTION
Currently, one environment can process an object from another environment, mark it as processed, but in fact he didn't do anything...

Same as: https://github.com/camptocamp/operator-shared-config-manager/pull/214