### PR TITLE
Fix integration production separation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install helm
         uses: azure/setup-helm@v3
+        with:
+          version: 3.10.0
       - run: helm lint .
 
       - name: Setup k3s/k3d

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,4 +41,4 @@ RUN --mount=type=cache,target=/root/.cache \
 
 WORKDIR /app
 COPY operator_.py ./
-CMD ["kopf", "run", "operator_.py"]
+ENTRYPOINT ["kopf", "run", "operator_.py"]

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,22 +29,9 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command:
-          {{- if .Values.command }}
-          {{- range .Values.command }}
-            - {{ . }}
-          {{- end }}
-          {{- else }}
-            - kopf
-            - run
-          {{- end }}
+          {{- with .Values.args }}
           args:
-          {{- if .Values.args }}
-          {{- range .Values.args }}
-            - {{ . }}
-          {{- end }}
-          {{- else }}
-            - operator_.py
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,7 @@ global:
 
 replicaCount: 1
 
+args: []
 env:
   GITHUB_TOKEN: required
   LOG_LEVEL: WARN


### PR DESCRIPTION
Currently one environment can process an object from an other environment, mark it as processed, but in fact he didn't do anything...

Same as https://github.com/camptocamp/operator-shared-config-manager/pull/214